### PR TITLE
fix: proxy blog feed for update workflow

### DIFF
--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gautamkrishnar/blog-post-workflow@v1
         with:
-          feed_list: "https://aiexponent.com/feed/"
+          # Use r.jina.ai as a proxy to work around 403 errors from the origin
+          feed_list: "https://r.jina.ai/https://aiexponent.com/feed/"
           max_post_count: 5
 


### PR DESCRIPTION
## Summary
- proxy blog RSS through r.jina.ai to avoid 403 errors in blog-post-workflow

## Testing
- `npx markdownlint README.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/markdownlint)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f62c9c8483218fe08b4fb25ea9f5