### PR TITLE
Fix blog post workflow: correct RSS feed URL and remove incompatible …

### DIFF
--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gautamkrishnar/blog-post-workflow@v1
         with:
-          # Use r.jina.ai as a proxy to work around 403 errors from the origin
-          feed_list: "https://r.jina.ai/https://aiexponent.com/feed"
+          feed_list: "https://aiexponent.com/feed/"
           max_post_count: 5
 


### PR DESCRIPTION
…proxy

- Changed feed URL from https://aiexponent.com/feed to https://aiexponent.com/feed/ (with trailing slash)
- Removed r.jina.ai proxy which was causing 422 errors with RSS content
- The workflow should now successfully fetch and update blog posts in README