### PR TITLE
Add permissions and explicit configuration for blog-post-workflow

### DIFF
--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 */12 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-readme-with-blog:
     runs-on: ubuntu-latest
@@ -13,4 +16,7 @@ jobs:
         with:
           feed_list: "https://aiexponent.com/feed/"
           max_post_count: 5
+          readme_path: "./README.md"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          comment_tag_name: "BLOG-POST-LIST"
 


### PR DESCRIPTION
- Added contents: write permission for the workflow
- Specified readme_path, gh_token, and comment_tag_name explicitly
- This should resolve the issue where blog posts weren't being updated in README